### PR TITLE
Add matching line break to end of msgstr

### DIFF
--- a/es/resource.po
+++ b/es/resource.po
@@ -72,7 +72,7 @@ msgstr ""
 "<p>Este es un conjunto de ocho tarjetas de consejos desarrolladas para "
 "abordar los problemas de alimentación en los bebés en el norte de "
 "Ghana.</p><div>Socios contribuyentes: MOH Ghana, CRS, UNICEF, Cruz Roja de "
-"Ghana</div>"
+"Ghana</div>\n"
 
 #: orb.models.Resource.title:52
 msgid "Initiation of Breastfeeding by Breast Crawl "


### PR DESCRIPTION
The msgstr must end with line break character is the msgid does.

This does not solve the Transifex issue but does resolve a fatal warning reported by the `msgfmt` utility. Can be run from command line like so:

    msgfmt -c resource.po